### PR TITLE
Add term publishing plugin commands to charm snap.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: charm
-version: 2.1
+version: 2.2
 summary: charm and charm-tools
 description: charmstore-client and charm-tools
 confinement: strict
@@ -19,13 +19,13 @@ parts:
     plugin: godeps
     go-importpath: github.com/juju/charmstore-client
     source: https://github.com/juju/charmstore-client.git
-    source-tag: 2.1.2
+    source-tag: 2.2.0
     source-type: git
   charm-terms:
     plugin: godeps
     go-importpath: github.com/juju/terms-client
     source: https://github.com/juju/terms-client.git
-    source-tag: v1.0.0
+    source-tag: v1.0.1
     source-type: git
   charm-tools:
     plugin: python2

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -21,6 +21,12 @@ parts:
     source: https://github.com/juju/charmstore-client.git
     source-tag: 2.1.2
     source-type: git
+  charm-terms:
+    plugin: godeps
+    go-importpath: github.com/juju/terms-client
+    source: https://github.com/juju/terms-client.git
+    source-tag: v1.0.0
+    source-type: git
   charm-tools:
     plugin: python2
     source: https://github.com/juju/charm-tools.git


### PR DESCRIPTION
This adds plugin commands for users to be able to publish their own terms:
`charm push-term`
`charm publish-term`
`charm show-term`